### PR TITLE
Extra bukkit api patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Gradle(Groovy DSL):
 compileOnly files("PATH-TO-JAR")
 ```
 
-APIs are located at `io.wdsj.hybridfix.api` package.
+APIs are located at `io.wdsj.hybridfix.api` and `io.wdsj.hybridfix.duck.api` package.
 
 ## Plugin Hooks
 Thanks to HybridFix internal plugin, we can hook into plugins from Forge side to provide more fixes.
@@ -106,3 +106,9 @@ Currently patched plugins:
 - `hybridfix.command.eraseentity.use` - Allow to access `/hybridfix eraseentity` command.
 
 **Note**: Commands and permissions are registered on Bukkit side, that means you can manage permissions with Bukkit permission plugins like LuckPerms.
+
+## License
+
+This mod is licensed under LGPL-2.1.
+
+It does not redistribute CraftBukkit or Minecraft code. The stripped MCP remapped CraftBukkit JAR in the repository is for development use only and not included in releases.

--- a/gradle.properties
+++ b/gradle.properties
@@ -101,7 +101,7 @@ mixin_booter_version = 10.6
 # You should change package root once they are generated
 generate_mixins_json = true
 # Delimit configs with spaces. Should only put configs name instead of full file name
-mixin_configs = fix.respawn fix.fakeplayer botania.block thaumcraft.flux epic_siege_mod.grief infernal_mobs.modifiers techguns.explosion applied_energistics_2.spatial reborncore.explosion botania.item draconic_evolution.entity ic2.explosion ic2.machine so_many_enchantments.disarm tconstruct.tools thaumcraft.taint twilight_forest.item twilight_forest.entity twilight_forest.sapling hybridfix.base bridge.explosion.mohist fix.respawn.mohist perf.eventbus perf.server perf.timings.v1 misc.command bukkit.plugin
+mixin_configs = fix.respawn fix.fakeplayer api.bukkit botania.block thaumcraft.flux epic_siege_mod.grief infernal_mobs.modifiers techguns.explosion applied_energistics_2.spatial reborncore.explosion botania.item draconic_evolution.entity ic2.explosion ic2.machine so_many_enchantments.disarm tconstruct.tools thaumcraft.taint twilight_forest.item twilight_forest.entity twilight_forest.sapling hybridfix.base bridge.explosion.mohist fix.respawn.mohist perf.eventbus perf.server perf.timings.v1 misc.command bukkit.plugin
 # A refmap is a json that denotes mapping conversions, this json is generated automatically, with the name `mixins.mod_id.refmap.json`
 # Use the property `mixin_refmap` if you want it to use a different name, only one name is accepted
 mixin_refmap = mixins.${mod_id}.refmap.json

--- a/src/main/java/io/wdsj/hybridfix/HybridFixPlugin.java
+++ b/src/main/java/io/wdsj/hybridfix/HybridFixPlugin.java
@@ -22,7 +22,7 @@ public class HybridFixPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
     {
         {
             put("mixins.hybridfix.base.json", () -> true);
-            put("mixins.api.bukkit.json", () -> Settings.experimentalBukkitApi);
+            put("mixins.api.bukkit.json", () -> Settings.extraBukkitApi);
             put("mixins.fix.fakeplayer.json", () -> Settings.invertFakePlayerBlacklist || Settings.fakePlayerPluginBlacklist.length > 0);
             put("mixins.fix.respawn.json", () -> Settings.fixCapabilityReset || Settings.simulateVanillaRespawn);
             if (!HAS_CLEANROOM) {

--- a/src/main/java/io/wdsj/hybridfix/HybridFixPlugin.java
+++ b/src/main/java/io/wdsj/hybridfix/HybridFixPlugin.java
@@ -22,6 +22,7 @@ public class HybridFixPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
     {
         {
             put("mixins.hybridfix.base.json", () -> true);
+            put("mixins.api.bukkit.json", () -> Settings.experimentalBukkitApi);
             put("mixins.fix.fakeplayer.json", () -> Settings.invertFakePlayerBlacklist || Settings.fakePlayerPluginBlacklist.length > 0);
             put("mixins.fix.respawn.json", () -> Settings.fixCapabilityReset || Settings.simulateVanillaRespawn);
             if (!HAS_CLEANROOM) {

--- a/src/main/java/io/wdsj/hybridfix/config/Settings.java
+++ b/src/main/java/io/wdsj/hybridfix/config/Settings.java
@@ -63,6 +63,10 @@ public class Settings {
     @Config.RequiresMcRestart
     public static boolean invertFakePlayerBlacklist = false;
 
+    @Config.Comment("[EXPERIMENTAL] More Bukkit API implementation.")
+    @Config.RequiresMcRestart
+    public static boolean experimentalBukkitApi = false;
+
     @Config.Comment("Configuration for HybridFix mod patches.")
     @Config.RequiresMcRestart
     public static ModPatchSettings modPatchSettings = new ModPatchSettings();

--- a/src/main/java/io/wdsj/hybridfix/config/Settings.java
+++ b/src/main/java/io/wdsj/hybridfix/config/Settings.java
@@ -65,7 +65,7 @@ public class Settings {
 
     @Config.Comment("[EXPERIMENTAL] More Bukkit API implementation.")
     @Config.RequiresMcRestart
-    public static boolean experimentalBukkitApi = false;
+    public static boolean extraBukkitApi = false;
 
     @Config.Comment("Configuration for HybridFix mod patches.")
     @Config.RequiresMcRestart

--- a/src/main/java/io/wdsj/hybridfix/duck/api/bukkit/block/IBlockInvoker.java
+++ b/src/main/java/io/wdsj/hybridfix/duck/api/bukkit/block/IBlockInvoker.java
@@ -3,7 +3,8 @@ package io.wdsj.hybridfix.duck.api.bukkit.block;
 import io.wdsj.hybridfix.HybridFixServer;
 
 /**
- * Duck interface for {@link org.bukkit.block.Block}
+ * Duck interface for {@link org.bukkit.block.Block}.
+ * All methods here behave same as <a href="https://jd.papermc.io/paper/1.21.5/org/bukkit/block/Block.html">PaperMC Javadoc</a>.
  */
 @SuppressWarnings("unused")
 public interface IBlockInvoker {

--- a/src/main/java/io/wdsj/hybridfix/duck/api/bukkit/block/IBlockInvoker.java
+++ b/src/main/java/io/wdsj/hybridfix/duck/api/bukkit/block/IBlockInvoker.java
@@ -5,6 +5,7 @@ import io.wdsj.hybridfix.HybridFixServer;
 /**
  * Duck interface for {@link org.bukkit.block.Block}.
  * All methods here behave same as <a href="https://jd.papermc.io/paper/1.21.5/org/bukkit/block/Block.html">PaperMC Javadoc</a>.
+ * You can cast to this interface from a {@link org.bukkit.block.Block} instance to access the methods below.
  */
 @SuppressWarnings("unused")
 public interface IBlockInvoker {

--- a/src/main/java/io/wdsj/hybridfix/duck/api/bukkit/block/IBlockInvoker.java
+++ b/src/main/java/io/wdsj/hybridfix/duck/api/bukkit/block/IBlockInvoker.java
@@ -1,0 +1,72 @@
+package io.wdsj.hybridfix.duck.api.bukkit.block;
+
+import io.wdsj.hybridfix.HybridFixServer;
+
+/**
+ * Duck interface for {@link org.bukkit.block.Block}
+ */
+@SuppressWarnings("unused")
+public interface IBlockInvoker {
+    /**
+     * Check if this block is solid
+     * <p>
+     * Determined by Minecraft, typically a block a player can use to place a new block to build things.
+     * An example of a non-buildable block would be liquids, flowers, or fire
+     *
+     * @return true if block is buildable
+     */
+    default boolean isBuildable() {
+        AssertionError error = new AssertionError("Not Implemented");
+        HybridFixServer.createServerDump(error);
+        throw error;
+    }
+
+    /**
+     * Check if this block is burnable
+     * <p>
+     * Determined by Minecraft, typically a block that fire can destroy (Wool, Wood)
+     *
+     * @return true if block is burnable
+     */
+    default boolean isBurnable() {
+        AssertionError error = new AssertionError("Not Implemented");
+        HybridFixServer.createServerDump(error);
+        throw error;
+    }
+
+    /**
+     * Check if this block is replaceable
+     * <p>
+     * Determined by Minecraft, representing a block that is not AIR that you can still place a new block at, such as flowers.
+     * @return true if block is replaceable
+     */
+    default boolean isReplaceable() {
+        AssertionError error = new AssertionError("Not Implemented");
+        HybridFixServer.createServerDump(error);
+        throw error;
+    }
+
+    /**
+     * Check if this block is solid
+     * <p>
+     * Determined by Minecraft, typically a block a player can stand on and can't be passed through.
+     * This API is faster and more accurate than accessing Material#isSolid as it avoids a material lookup and switch statement.
+     * @return true if block is solid
+     */
+    default boolean isSolid() {
+        AssertionError error = new AssertionError("Not Implemented");
+        HybridFixServer.createServerDump(error);
+        throw error;
+    }
+
+    /**
+     * Checks if this block is collidable.
+     *
+     * @return true if collidable
+     */
+    default boolean isCollidable() {
+        AssertionError error = new AssertionError("Not Implemented");
+        HybridFixServer.createServerDump(error);
+        throw error;
+    }
+}

--- a/src/main/java/io/wdsj/hybridfix/duck/api/bukkit/event/block/IActionInvoker.java
+++ b/src/main/java/io/wdsj/hybridfix/duck/api/bukkit/event/block/IActionInvoker.java
@@ -3,7 +3,8 @@ package io.wdsj.hybridfix.duck.api.bukkit.event.block;
 import io.wdsj.hybridfix.HybridFixServer;
 
 /**
- * Duck interface for {@link org.bukkit.event.block.Action}
+ * Duck interface for {@link org.bukkit.event.block.Action}.
+ * You can cast to this from an {@link org.bukkit.event.block.Action} instance.
  */
 @SuppressWarnings("unused")
 public interface IActionInvoker {

--- a/src/main/java/io/wdsj/hybridfix/duck/api/bukkit/event/block/IActionInvoker.java
+++ b/src/main/java/io/wdsj/hybridfix/duck/api/bukkit/event/block/IActionInvoker.java
@@ -1,0 +1,31 @@
+package io.wdsj.hybridfix.duck.api.bukkit.event.block;
+
+import io.wdsj.hybridfix.HybridFixServer;
+
+/**
+ * Duck interface for {@link org.bukkit.event.block.Action}
+ */
+@SuppressWarnings("unused")
+public interface IActionInvoker {
+    /**
+     * Gets whether this action is a result of a left click.
+     *
+     * @return Whether it's a left click
+     */
+    default boolean isLeftClick() {
+        AssertionError error = new AssertionError("Not Implemented");
+        HybridFixServer.createServerDump(error);
+        throw error;
+    }
+
+    /**
+     * Gets whether this action is a result of a right click.
+     *
+     * @return Whether it's a right click
+     */
+    default boolean isRightClick() {
+        AssertionError error = new AssertionError("Not Implemented");
+        HybridFixServer.createServerDump(error);
+        throw error;
+    }
+}

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/BlockMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/BlockMixin.java
@@ -4,6 +4,10 @@ import org.bukkit.block.Block;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
+/**
+ * Implemented by {@link CraftBlockMixin}.
+ * All methods here behave same as <a href="https://jd.papermc.io/paper/1.21.5/org/bukkit/block/Block.html">PaperMC Javadoc</a>
+ */
 @Mixin(value = Block.class, remap = false)
 public interface BlockMixin {
     @Unique

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/BlockMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/BlockMixin.java
@@ -1,0 +1,13 @@
+package io.wdsj.hybridfix.mixin.api.bukkit.block;
+
+import org.bukkit.block.Block;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(value = Block.class, remap = false)
+public interface BlockMixin {
+    @Unique
+    default boolean isSolid() {
+        return true;
+    }
+}

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/BlockMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/BlockMixin.java
@@ -6,7 +6,6 @@ import org.spongepowered.asm.mixin.Unique;
 
 /**
  * Implemented by {@link CraftBlockMixin}.
- * All methods here behave same as <a href="https://jd.papermc.io/paper/1.21.5/org/bukkit/block/Block.html">PaperMC Javadoc</a>
  */
 @Mixin(value = Block.class, remap = false)
 public interface BlockMixin {

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/BlockMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/BlockMixin.java
@@ -7,7 +7,27 @@ import org.spongepowered.asm.mixin.Unique;
 @Mixin(value = Block.class, remap = false)
 public interface BlockMixin {
     @Unique
+    default boolean isBuildable() {
+        return true;
+    }
+
+    @Unique
+    default boolean isBurnable() {
+        return false;
+    }
+
+    @Unique
+    default boolean isReplaceable() {
+        return false;
+    }
+
+    @Unique
     default boolean isSolid() {
+        return true;
+    }
+
+    @Unique
+    default boolean isCollidable() {
         return true;
     }
 }

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/CraftBlockMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/CraftBlockMixin.java
@@ -1,5 +1,6 @@
 package io.wdsj.hybridfix.mixin.api.bukkit.block;
 
+import io.wdsj.hybridfix.duck.api.bukkit.block.IBlockInvoker;
 import net.minecraft.util.math.BlockPos;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_12_R1.CraftChunk;
@@ -16,7 +17,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * Works along with {@link BlockMixin}
  */
 @Mixin(value = CraftBlock.class, remap = false)
-public abstract class CraftBlockMixin {
+public abstract class CraftBlockMixin implements IBlockInvoker {
     // @formatter:off
     @Shadow public abstract World getWorld();
     @Unique private BlockPos hybridFix$pos;
@@ -31,26 +32,31 @@ public abstract class CraftBlockMixin {
     }
 
     @Unique
+    @Override
     public boolean isBuildable() {
         return ((CraftWorld) this.getWorld()).getHandle().getBlockState(hybridFix$pos).getMaterial().isSolid();
     }
 
     @Unique
+    @Override
     public boolean isBurnable() {
         return ((CraftWorld) this.getWorld()).getHandle().getBlockState(hybridFix$pos).getMaterial().getCanBurn();
     }
 
     @Unique
+    @Override
     public boolean isReplaceable() {
         return ((CraftWorld) this.getWorld()).getHandle().getBlockState(hybridFix$pos).getMaterial().isReplaceable();
     }
 
     @Unique
+    @Override
     public boolean isSolid() {
         return ((CraftWorld) this.getWorld()).getHandle().getBlockState(hybridFix$pos).getMaterial().blocksMovement();
     }
 
     @Unique
+    @Override
     public boolean isCollidable() {
         net.minecraft.world.World world = ((CraftWorld) this.getWorld()).getHandle();
         return world.getBlockState(hybridFix$pos).getCollisionBoundingBox(world, hybridFix$pos) != null;

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/CraftBlockMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/CraftBlockMixin.java
@@ -31,7 +31,28 @@ public abstract class CraftBlockMixin {
     }
 
     @Unique
+    public boolean isBuildable() {
+        return ((CraftWorld) this.getWorld()).getHandle().getBlockState(hybridFix$pos).getMaterial().isSolid();
+    }
+
+    @Unique
+    public boolean isBurnable() {
+        return ((CraftWorld) this.getWorld()).getHandle().getBlockState(hybridFix$pos).getMaterial().getCanBurn();
+    }
+
+    @Unique
+    public boolean isReplaceable() {
+        return ((CraftWorld) this.getWorld()).getHandle().getBlockState(hybridFix$pos).getMaterial().isReplaceable();
+    }
+
+    @Unique
     public boolean isSolid() {
         return ((CraftWorld) this.getWorld()).getHandle().getBlockState(hybridFix$pos).getMaterial().blocksMovement();
+    }
+
+    @Unique
+    public boolean isCollidable() {
+        net.minecraft.world.World world = ((CraftWorld) this.getWorld()).getHandle();
+        return world.getBlockState(hybridFix$pos).getCollisionBoundingBox(world, hybridFix$pos) != null;
     }
 }

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/CraftBlockMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/CraftBlockMixin.java
@@ -1,0 +1,37 @@
+package io.wdsj.hybridfix.mixin.api.bukkit.block;
+
+import net.minecraft.util.math.BlockPos;
+import org.bukkit.World;
+import org.bukkit.craftbukkit.v1_12_R1.CraftChunk;
+import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_12_R1.block.CraftBlock;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Works along with {@link BlockMixin}
+ */
+@Mixin(value = CraftBlock.class, remap = false)
+public abstract class CraftBlockMixin {
+    // @formatter:off
+    @Shadow public abstract World getWorld();
+    @Unique private BlockPos hybridFix$pos;
+    // @formatter:on
+
+    @Inject(
+            method = "<init>",
+            at = @At("RETURN")
+    )
+    public void init(CraftChunk chunk, int x, int y, int z, CallbackInfo ci) {
+        this.hybridFix$pos = new BlockPos(x, y, z);
+    }
+
+    @Unique
+    public boolean isSolid() {
+        return ((CraftWorld) this.getWorld()).getHandle().getBlockState(hybridFix$pos).getMaterial().blocksMovement();
+    }
+}

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/CraftBlockMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/block/CraftBlockMixin.java
@@ -1,6 +1,7 @@
 package io.wdsj.hybridfix.mixin.api.bukkit.block;
 
 import io.wdsj.hybridfix.duck.api.bukkit.block.IBlockInvoker;
+import net.minecraft.block.Block;
 import net.minecraft.util.math.BlockPos;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_12_R1.CraftChunk;
@@ -20,6 +21,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class CraftBlockMixin implements IBlockInvoker {
     // @formatter:off
     @Shadow public abstract World getWorld();
+    @Shadow protected abstract Block getNMSBlock();
     @Unique private BlockPos hybridFix$pos;
     // @formatter:on
 
@@ -46,7 +48,8 @@ public abstract class CraftBlockMixin implements IBlockInvoker {
     @Unique
     @Override
     public boolean isReplaceable() {
-        return ((CraftWorld) this.getWorld()).getHandle().getBlockState(hybridFix$pos).getMaterial().isReplaceable();
+        net.minecraft.world.World world = ((CraftWorld) this.getWorld()).getHandle();
+        return this.getNMSBlock().isReplaceable(world, hybridFix$pos);
     }
 
     @Unique

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/entity/CraftPlayerMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/entity/CraftPlayerMixin.java
@@ -1,0 +1,108 @@
+package io.wdsj.hybridfix.mixin.api.bukkit.entity;
+
+import io.wdsj.hybridfix.api.bukkit.HybridFixBukkitApi;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.minecraft.entity.player.EntityPlayerMP;
+import org.bukkit.Effect;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@SuppressWarnings("deprecation")
+@Mixin(value = CraftPlayer.class, remap = false)
+public abstract class CraftPlayerMixin {
+    // @formatter:off
+    @Shadow public abstract EntityPlayerMP getHandle();
+    // @formatter:on
+
+    @Unique
+    private final Player.Spigot hybridFix$fakePlayerSpigot = new Player.Spigot() {
+        public InetSocketAddress getRawAddress() {
+            return null;
+        }
+
+        public boolean getCollidesWithEntities() {
+            return false;
+        }
+
+        public void setCollidesWithEntities(boolean collides) {
+        }
+
+        public void respawn() {
+        }
+
+        public void playEffect(Location location, Effect effect, int id, int data, float offsetX, float offsetY, float offsetZ, float speed, int particleCount, int radius) {
+        }
+
+        public String getLocale() {
+            return "en_US";
+        }
+
+        public Set<Player> getHiddenPlayers() {
+            return Collections.unmodifiableSet(new HashSet<>());
+        }
+
+        public void sendMessage(BaseComponent component) {
+        }
+
+        public void sendMessage(BaseComponent... components) {
+        }
+
+        public void sendMessage(ChatMessageType position, BaseComponent component) {
+        }
+
+        public void sendMessage(ChatMessageType position, BaseComponent... components) {
+        }
+    };
+
+    @Inject(
+            method = "spigot()Lorg/bukkit/entity/Player$Spigot;",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    public void spigot(CallbackInfoReturnable<Player.Spigot> cir) {
+        if (HybridFixBukkitApi.getApi().isFakePlayer((CraftPlayer) (Object) this)) {
+            cir.setReturnValue(hybridFix$fakePlayerSpigot);
+        }
+    }
+
+    @Inject(
+            method = "sendHealthUpdate",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    public void sendHealthUpdate(CallbackInfo ci) {
+        if (this.getHandle().connection == null) ci.cancel();
+    }
+
+    @Inject(
+            method = "sendTitle(Ljava/lang/String;Ljava/lang/String;III)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    public void sendTitle(String title, String subtitle, int fadeInTicks, int stayTicks, int fadeOutTicks, CallbackInfo ci) {
+        if (this.getHandle().connection == null) ci.cancel();
+    }
+
+    @Inject(
+            method = "spawnParticle(Lorg/bukkit/Particle;DDDIDDDDLjava/lang/Object;)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    public void spawnParticle(CallbackInfo ci) {
+        if (this.getHandle().connection == null) ci.cancel();
+    }
+}

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/entity/CraftPlayerMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/entity/CraftPlayerMixin.java
@@ -26,8 +26,6 @@ import java.util.Set;
 public abstract class CraftPlayerMixin {
     // @formatter:off
     @Shadow public abstract EntityPlayerMP getHandle();
-    // @formatter:on
-
     @Unique
     private final Player.Spigot hybridFix$fakePlayerSpigot = new Player.Spigot() {
         public InetSocketAddress getRawAddress() {
@@ -67,6 +65,7 @@ public abstract class CraftPlayerMixin {
         public void sendMessage(ChatMessageType position, BaseComponent... components) {
         }
     };
+    // @formatter:on
 
     @Inject(
             method = "spigot()Lorg/bukkit/entity/Player$Spigot;",

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/event/block/ActionMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/event/block/ActionMixin.java
@@ -1,5 +1,6 @@
 package io.wdsj.hybridfix.mixin.api.bukkit.event.block;
 
+import io.wdsj.hybridfix.duck.api.bukkit.event.block.IActionInvoker;
 import org.bukkit.event.block.Action;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -8,23 +9,15 @@ import static org.bukkit.event.block.Action.*;
 
 @SuppressWarnings({"unused", "ConstantConditions"})
 @Mixin(value = Action.class, remap = false)
-public abstract class ActionMixin {
-    /**
-     * Gets whether this action is a result of a left click.
-     *
-     * @return Whether it's a left click
-     */
+public abstract class ActionMixin implements IActionInvoker {
     @Unique
+    @Override
     public boolean isLeftClick() {
         return (Object) this == LEFT_CLICK_AIR || (Object) this == LEFT_CLICK_BLOCK;
     }
 
-    /**
-     * Gets whether this action is a result of a right click.
-     *
-     * @return Whether it's a right click
-     */
     @Unique
+    @Override
     public boolean isRightClick() {
         return (Object) this == RIGHT_CLICK_AIR || (Object) this == RIGHT_CLICK_BLOCK;
     }

--- a/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/event/block/ActionMixin.java
+++ b/src/main/java/io/wdsj/hybridfix/mixin/api/bukkit/event/block/ActionMixin.java
@@ -1,0 +1,31 @@
+package io.wdsj.hybridfix.mixin.api.bukkit.event.block;
+
+import org.bukkit.event.block.Action;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import static org.bukkit.event.block.Action.*;
+
+@SuppressWarnings({"unused", "ConstantConditions"})
+@Mixin(value = Action.class, remap = false)
+public abstract class ActionMixin {
+    /**
+     * Gets whether this action is a result of a left click.
+     *
+     * @return Whether it's a left click
+     */
+    @Unique
+    public boolean isLeftClick() {
+        return (Object) this == LEFT_CLICK_AIR || (Object) this == LEFT_CLICK_BLOCK;
+    }
+
+    /**
+     * Gets whether this action is a result of a right click.
+     *
+     * @return Whether it's a right click
+     */
+    @Unique
+    public boolean isRightClick() {
+        return (Object) this == RIGHT_CLICK_AIR || (Object) this == RIGHT_CLICK_BLOCK;
+    }
+}

--- a/src/main/resources/mixins.api.bukkit.json
+++ b/src/main/resources/mixins.api.bukkit.json
@@ -1,0 +1,13 @@
+{
+  "package": "io.wdsj.hybridfix.mixin.api.bukkit",
+  "required": true,
+  "refmap": "${mixin_refmap}",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "block.CraftBlockMixin",
+    "block.BlockMixin",
+    "entity.CraftPlayerMixin"
+  ]
+}

--- a/src/main/resources/mixins.api.bukkit.json
+++ b/src/main/resources/mixins.api.bukkit.json
@@ -8,6 +8,7 @@
   "mixins": [
     "block.CraftBlockMixin",
     "block.BlockMixin",
-    "entity.CraftPlayerMixin"
+    "entity.CraftPlayerMixin",
+    "event.block.ActionMixin"
   ]
 }


### PR DESCRIPTION
### Tasks
- [x] Patch CraftPlayer to make it safer to call for Forge FakePlayers.
- [x] Backport Block API from modern Paper versions.
- [x] Backport helper methods in `org.bukkit.event.block.Action` from modern Paper versions.